### PR TITLE
Fix invalid copy to clipboard command

### DIFF
--- a/plugin/to-github.vim
+++ b/plugin/to-github.vim
@@ -50,7 +50,7 @@ endfunction
 
 function! s:copy_to_clipboard(url)
   if exists('g:to_github_clip_command')
-    call system(g:gist_clip_command, a:url)
+    call system(g:to_github_clip_command, a:url)
   elseif has('unix') && !has('xterm_clipboard')
     let @" = a:url
   else


### PR DESCRIPTION
Before fix I get an error when tried to use plugin in copy to clipboard mode (as described in readme).
