### PR TITLE
Substitute repository root from file_path

### DIFF
--- a/plugin/to-github.vim
+++ b/plugin/to-github.vim
@@ -81,7 +81,9 @@ function! ToGithub(count, line1, line2, ...)
 
   " Get the branch and path, and form the complete url.
   let branch = s:run('git symbolic-ref --short HEAD')
+  let repo_root = s:run('git rev-parse --show-toplevel')
   let file_path = bufname('%')
+  let file_path = substitute(file_path, repo_root . '/', '', 'e')
   let url = join([github_url, username, repo, 'blob', branch, file_path], '/')
 
   " Finally set the line numbers if necessary.


### PR DESCRIPTION
Fixes #6.

| Key | Value |
| :-- | :-- |
| git rev-parse --show-toplevel | /Users/k0kubun/src/github.com/tonchis/vim-to-github |
| expected file_name | plugin/to-github.vim |
| actual file_name (`bufname('%')`) | /Users/k0kubun/src/github.com/tonchis/vim-to-github/plugin/to-github.vim |

You can detect repository root path by `git rev-parse --show-toplevel`.
If `file_path` contains the string, it is invalid for GitHub url and the same as an unnecessary part of unexpected url.

Thus I removed a repository root path from `file_path` if exists.
