### PR TITLE
get_remote should not return more than 1 line

### DIFF
--- a/plugin/to-github.vim
+++ b/plugin/to-github.vim
@@ -60,7 +60,7 @@ endfunction
 
 function! ToGithub(count, line1, line2, ...)
   let github_url = 'https://github.com'
-  let get_remote = 'git remote -v | grep -E "github\.com.*\(fetch\)"'
+  let get_remote = 'git remote -v | grep -E "github\.com.*\(fetch\)" | head -n 1'
   let get_username = 'sed -E "s/.*com[:\/](.*)\/.*/\\1/"'
   let get_repo = 'sed -E "s/.*com[:\/].*\/(.*).*/\\1/" | cut -d " " -f 1'
   let optional_ext = 'sed -E "s/\.git//"'


### PR DESCRIPTION
otherwise it's broken in the case of multiple remotes.
