### PR TITLE
Use commit rather than branch in url.

### DIFF
--- a/plugin/to-github.vim
+++ b/plugin/to-github.vim
@@ -79,8 +79,8 @@ function! ToGithub(count, line1, line2, ...)
     return 'Too many arguments'
   endif
 
-  " Get the branch and path, and form the complete url.
-  let branch = s:run('git symbolic-ref --short HEAD')
+  " Get the commit and path, and form the complete url.
+  let branch = s:run('git show-ref --hash HEAD')
   let repo_root = s:run('git rev-parse --show-toplevel')
   let file_path = bufname('%')
   let file_path = substitute(file_path, repo_root . '/', '', 'e')


### PR DESCRIPTION
Great plugin!

Just one thing, when I make github links I want them to be [permanent links](https://help.github.com/articles/getting-permanent-links-to-files/), and to do that we need the commit hash not the branch name. I've made a minor change to do that.