### PR TITLE
Fix full path of file

### DIFF
--- a/plugin/to-github.vim
+++ b/plugin/to-github.vim
@@ -82,7 +82,7 @@ function! ToGithub(count, line1, line2, ...)
   " Get the commit and path, and form the complete url.
   let commit = s:run('git rev-parse HEAD')
   let repo_root = s:run('git rev-parse --show-toplevel')
-  let file_path = bufname('%')
+  let file_path = expand('%:p')
   let file_path = substitute(file_path, repo_root . '/', '', 'e')
   let url = join([github_url, username, repo, 'blob', commit, file_path], '/')
 


### PR DESCRIPTION
If the `cwd` is an inner directory inside the repo, we get the full path which we remove the full path of the repo either way:
https://github.com/tonchis/vim-to-github/pull/13/files#diff-1d8cda0529b884127c8639fa7247f9d4R86
