### PR TITLE
Add :ToGithubBlame to open blame route for same file location

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ It's the same to replace the repo name:
 :ToGithub username repo
 ```
 
+You can also open the blame route:
+
+```
+:ToGithubBlame
+```
+
 You can also set a global option to copy the url in the clipboard instead of opening the browser
 
 ```

--- a/plugin/to-github.vim
+++ b/plugin/to-github.vim
@@ -58,7 +58,7 @@ function! s:copy_to_clipboard(url)
   endif
 endfunction
 
-function! ToGithub(count, line1, line2, ...)
+function! ToGithub(route, count, line1, line2, ...)
   let github_url = 'https://github.com'
   let get_remote = 'git remote -v | grep -E "github\.com.*\(fetch\)" | head -n 1'
   let get_username = 'sed -E "s/.*com[:\/](.*)\/.*/\\1/"'
@@ -84,7 +84,7 @@ function! ToGithub(count, line1, line2, ...)
   let repo_root = s:run('git rev-parse --show-toplevel')
   let file_path = expand('%:p')
   let file_path = substitute(file_path, repo_root . '/', '', 'e')
-  let url = join([github_url, username, repo, 'blob', commit, file_path], '/')
+  let url = join([github_url, username, repo, a:route, commit, file_path], '/')
 
   " Finally set the line numbers if necessary.
   if a:count == -1
@@ -100,4 +100,5 @@ function! ToGithub(count, line1, line2, ...)
   endif
 endfunction
 
-command! -nargs=* -range ToGithub :call ToGithub(<count>, <line1>, <line2>, <f-args>)
+command! -nargs=* -range ToGithub :call ToGithub('blob', <count>, <line1>, <line2>, <f-args>)
+command! -nargs=* -range ToGithubBlame :call ToGithub('blame', <count>, <line1>, <line2>, <f-args>)


### PR DESCRIPTION
Closes https://github.com/tonchis/vim-to-github/issues/14!

This PR adds `:ToGithubBlame` so users can open the "blame" route in GitHub for the same file location.

This is achieved simply by replacing "blob" with "blame" in the URL.  For example, for this "blob" route...

[ https://github.com/tonchis/vim-to-github/blob/9ea9c75b6cd48bd42823a39c56a05a2ff8161536/plugin/to-github.vim#L51-L59](https://github.com/tonchis/vim-to-github/blob/9ea9c75b6cd48bd42823a39c56a05a2ff8161536/plugin/to-github.vim#L51-L59)

...we can also use this "blame" route:

https://github.com/tonchis/vim-to-github/blame/9ea9c75b6cd48bd42823a39c56a05a2ff8161536/plugin/to-github.vim#L51-L59
