### PR TITLE
Always display code view in GitHub

### DIFF
--- a/plugin/to-github.vim
+++ b/plugin/to-github.vim
@@ -88,9 +88,9 @@ function! ToGithub(count, line1, line2, ...)
 
   " Finally set the line numbers if necessary.
   if a:count == -1
-    let line = '#L' . line('.')
+    let line = '?plain=1#L' . line('.')
   else
-    let line = '#L' . a:line1 . '-L' . a:line2
+    let line = '?plain=1#L' . a:line1 . '-L' . a:line2
   endif
 
   if get(g:, 'to_github_clipboard', 0)


### PR DESCRIPTION
Fixes https://github.com/tonchis/vim-to-github/issues/16!

This PR adds `?plain=1` to the URLs so that GitHub always opens in the code view.  This is helpful when working in markdown, for example, because GitHub would simply display the HTML-rendered markdown otherwise.

From https://github.com/tonchis/vim-to-github/issues/16:

> When viewing a markdown file, if I run `:ToGithub`, I get a URL like:
> 
> [ https://github.com/tonchis/vim-to-github/blob/9ea9c75b6cd48bd42823a39c56a05a2ff8161536/README.md#L3-L3](https://github.com/tonchis/vim-to-github/blob/9ea9c75b6cd48bd42823a39c56a05a2ff8161536/README.md#L3-L3)
> 
> However, this link brings up the HTML representation of the markdown file, not the lines of code:
> 
> ![image](https://github.com/tonchis/vim-to-github/assets/820984/11d62f19-0e97-4382-8e37-1d89bbb13559)
> 
> To always make the permalink open the lines of code, we want to add `?plain=1` to the URL, like so:
> 
> [ https://github.com/tonchis/vim-to-github/blob/9ea9c75b6cd48bd42823a39c56a05a2ff8161536/README.md?plain=1#L3-L3](https://github.com/tonchis/vim-to-github/blob/9ea9c75b6cd48bd42823a39c56a05a2ff8161536/README.md?plain=1#L3-L3)
> 
> This is the same as clicking the Code button without `?plain=1`, and `?plain=1` also enables the "code" mode:
> 
> ![image](https://github.com/tonchis/vim-to-github/assets/820984/8f886e6a-5378-46e1-b76f-c1784f6467e5)
> 
> This also works well on files that don't have any "viewer" in github that would default to the "code" view.  Plus, it's more explicit, which I think is a good thing.  Here's an example:
> 
> [ https://github.com/tonchis/vim-to-github/blob/9ea9c75b6cd48bd42823a39c56a05a2ff8161536/plugin/to-github.vim?plain=1#L46-L49](https://github.com/tonchis/vim-to-github/blob/9ea9c75b6cd48bd42823a39c56a05a2ff8161536/plugin/to-github.vim?plain=1#L46-L49)
> 
> And here's the link directly placed in the issue, where you can still see that the snippet is displayed:
> 
> https://github.com/tonchis/vim-to-github/blob/9ea9c75b6cd48bd42823a39c56a05a2ff8161536/plugin/to-github.vim?plain=1#L46-L49
> 
> We should add `?plain=1` for all generated links!  This will make the links always go to lines of code, no matter what :ok_hand: 