### PR TITLE
Always assume origin is a GitHub instance (adds support for self-hosted GitHub Enterprise URLs)

### DIFF
--- a/plugin/to-github.vim
+++ b/plugin/to-github.vim
@@ -59,11 +59,13 @@ function! s:copy_to_clipboard(url)
 endfunction
 
 function! ToGithub(count, line1, line2, ...)
-  let github_url = 'https://github.com'
-  let get_remote = 'git remote -v | grep -E "github\.com.*\(fetch\)" | head -n 1'
+  let get_remote = 'git remote -v | grep -E "^origin	+.*\(fetch\)$" | head -n 1' " Uses literal tab stop in regex.
+  let get_host = 'sed "s/^origin\t[^@]\+@\([^:]\+\).*/\1/"'
   let get_username = 'sed -E "s/.*com[:\/](.*)\/.*/\\1/"'
   let get_repo = 'sed -E "s/.*com[:\/].*\/(.*).*/\\1/" | cut -d " " -f 1'
   let optional_ext = 'sed -E "s/\.git//"'
+
+  let github_url = 'https://' . s:run(get_remote, get_host)
 
   " Get the username and repo.
   if len(a:000) == 0

--- a/plugin/to-github.vim
+++ b/plugin/to-github.vim
@@ -60,7 +60,7 @@ endfunction
 
 function! ToGithub(count, line1, line2, ...)
   let get_remote = 'git remote -v | grep -E "^origin	+.*\(fetch\)$" | head -n 1' " Uses literal tab stop in regex.
-  let get_host = 'sed "s/^origin\t[^@]\+@\([^:]\+\).*/\1/"'
+  let get_host = 'sed "s,^origin\t\+\([^@]\+@\|https://\)\([^/:]\+\).*,\2,"'
   let get_username = 'sed -E "s/.*com[:\/](.*)\/.*/\\1/"'
   let get_repo = 'sed -E "s/.*com[:\/].*\/(.*).*/\\1/" | cut -d " " -f 1'
   let optional_ext = 'sed -E "s/\.git//"'


### PR DESCRIPTION
Fixes https://github.com/tonchis/vim-to-github/issues/18!

This PR assumes that the origin repo is always a GitHub instance, which adds compatibility for company-hosted GitHub Enterprise instances with a different site name.  This replaces the hard-coded `github.com` in the regex and `https://github.com` in the URL output with an additional `sed` command to capture the site name and reuse it in the URL.

For example, with an upstream origin URL of...

`git@github.mycompany.com:example-org/example-repo.git`

...this PR would produce this URL for a few lines on `README.md`:

`https://github.mycompany.com/example-org/example-repo/blob/caf758b2dbe03480dd340dd339379ca86797e6b6/README.md#L11-L27`

Prior to this PR, a URL like this is produced:

`https://github.com///blob/caf758b2dbe03480dd340dd339379ca86797e6b6/README.md#L11-L27`